### PR TITLE
CodeCov + Coverage.py

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+branch = True
+omit = 
+    *migrations*
+
+[report]
+omit = 
+    *migrations*
+
+[html]
+directory = coverage_html_report
+

--- a/.github/workflows/build_BE.yml
+++ b/.github/workflows/build_BE.yml
@@ -28,17 +28,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      # Insert Other Steps Here
       - name: Run Pytest
-        run: |
-          pytest -v --cov=./ --cov-report=xml
+        run: pytest -v --cov=./ --cov-report=xml
 
       - name: Code Coverage Report
         uses: codecov/codecov-action@v1.0.14
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: Django Unchained - Backend
-          file: coverage.xml
+          files: ./backend/coverage.xml
           fail_ci_if_error: false
           verbose: true
 

--- a/.github/workflows/build_BE.yml
+++ b/.github/workflows/build_BE.yml
@@ -30,7 +30,21 @@ jobs:
 
       # Insert Other Steps Here
       - name: Run Pytest
-        run: pytest test_dummy.py --junitxml=report.xml
+        run: pytest test_dummy.py --cov-report=xml
+
+      - name: Code Coverage Report
+        uses: codecov/codecov-action@v1.0.14
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: Django Unchained - Backend
+          file: ./coverage.xml
+          fail_ci_if_error: false
+          verbose: true
+
+      - name: Black Code Formatter
+        uses: lgeiger/black-action@master
+        with:
+          args: "*/*.py --check"
 
       - name: Run Jest
         working-directory: ./frontend

--- a/.github/workflows/build_BE.yml
+++ b/.github/workflows/build_BE.yml
@@ -30,14 +30,15 @@ jobs:
 
       # Insert Other Steps Here
       - name: Run Pytest
-        run: pytest test_dummy.py --cov-report=xml
+        run: |
+          pytest -v --cov=./ --cov-report=xml
 
       - name: Code Coverage Report
         uses: codecov/codecov-action@v1.0.14
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: Django Unchained - Backend
-          file: ./coverage.xml
+          file: coverage.xml
           fail_ci_if_error: false
           verbose: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,10 @@
 venv
 __pycache__
 .tox
+coverage_html_report
+.pytest_cache
 
 # Files
 db.sqlite3
 .coverage
-.pytest_cache
-coverage_html_report
+coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Directories
+venv
+__pycache__
+.tox
+
+# Files
+db.sqlite3
+.coverage
+.pytest_cache
+coverage_html_report

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: backend
+backend:
+	find . | grep -E "(__pycache__|\.pyc|\.pyo)" | xargs rm -rf
+	black backend/*/*.py
+	# cd .. && tox && cd ..
+	coverage erase
+	coverage run --source=backend -m pytest -v
+	coverage report -m
+	coverage html

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,6 +1,0 @@
-# Directories
-venv
-__pycache__
-
-# Files
-db.sqlite3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,6 +23,8 @@ pyflakes==2.2.0
 pynt==0.8.2
 pyparsing==2.4.7
 pytest==6.1.2
+pytest-cov==2.10.1
+pytest-django==4.1.0
 pytz==2020.4
 regex==2020.10.28
 six==1.15.0

--- a/backend/tox.ini
+++ b/backend/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = 
+    py3,
+    lint,
+skipsdist = True
+
+[testenv:py3]
+deps = -r requirements.txt
+commands = pytest -v
+
+[pytest]
+DJANGO_SETTINGS_MODULE = backend.settings
+python_files = test*.py
+
+[testenv:lint]
+whitelist_externals = black
+commands = black api/ backend/


### PR DESCRIPTION
Notes:
- Added `CodeCov` action to workflow
- Added `coverage.py` commands for running and reporting results. Checkout Makefile `backend` target.
- Moved `.gitignore` to root level and added additional files + directories.
- Created a `Makefile` to run backend command. 
  - This is temporary though. We should be using `pynt` instead, but I didn't know how to use it at the time. 
  - Feel free to change it if you have prior knowledge. 
- Added `tox` (see commend below)