### PR TITLE
View: Application Create

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,4 +1,3 @@
-import os
 from api.models import User, Store, Item, History_of_Item
 from rest_framework import viewsets
 from rest_framework.response import Response
@@ -209,7 +208,7 @@ class RegisterUserViewSet(viewsets.ViewSet):
     permission_classes = []
 
     def create(self, request):
-        data = request.POST
+        data = request.data
         try:
             user = User.objects.create_user(
                 email=data.get("email"), password=data.get("password")
@@ -217,10 +216,17 @@ class RegisterUserViewSet(viewsets.ViewSet):
         except IntegrityError:
             return Response(data={"status": 0}, status=status.HTTP_400_BAD_REQUEST)
         else:
-            application = Application.objects.get(
-                client_id=os.getenv("CLIENT_ID", "defaultTestClientID")
+            application = Application.objects.create(
+                client_id="".join(random.choice(string.ascii_letters) for i in range(40)),
+                client_secret="".join(random.choice(string.ascii_letters) for i in range(128)),
+                authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+                client_type=Application.CLIENT_CONFIDENTIAL,
+                name="PyMarket-API",
+                redirect_uris="http://127.0.0.1:8000/authredirect/",
+                user=user,
             )
-            TOKEN = "".join(random.choice(string.ascii_letters) for i in range(25))
+            application.save()
+            TOKEN = "".join(random.choice(string.ascii_letters) for i in range(30))
             token = AccessToken.objects.create(
                 user=user,
                 token=TOKEN,


### PR DESCRIPTION
I was exploring the login functionality when I realized that the entries in the `oauth_application` and `oauth_token` tables were both tied to unique `user_id` and `client_id` otherwise `IntegrityError` is raised. So looking at the previous credentials I hard-coded, I added a temporary fix that will generate random credentials of appropriate length. 

![Screen Shot 2020-11-21 at 4 38 17 PM](https://user-images.githubusercontent.com/15621895/99888265-83aeaf00-2c19-11eb-911f-5ec91efa7d68.png)

![Screen Shot 2020-11-21 at 4 38 35 PM](https://user-images.githubusercontent.com/15621895/99888266-84474580-2c19-11eb-81bf-dd9db040160d.png)

![Screen Shot 2020-11-21 at 4 38 51 PM](https://user-images.githubusercontent.com/15621895/99888267-84dfdc00-2c19-11eb-8b51-ceac1ff8b8a9.png)
